### PR TITLE
FIX

### DIFF
--- a/apps/content-authoring/package.json
+++ b/apps/content-authoring/package.json
@@ -74,6 +74,6 @@
     "@electron-forge/maker-zip": "^6.0.0-beta.63",
     "@electron-forge/publisher-github": "^6.0.0-beta.63",
     "electron": "18.0.1",
-    "electron-prebuilt-compile": "^8.2.0"
+    "electron-prebuilt-compile": "8.2.0"
   }
 }


### PR DESCRIPTION
Error: You must depend on an EXACT version of "electron-prebuilt-compile" not a range (got "^8.2.0")