### PR TITLE
FIX - workflow error

### DIFF
--- a/.github/workflows/prerelease.yml
+++ b/.github/workflows/prerelease.yml
@@ -9,7 +9,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        os: [macos-latest, windows-latest]
+        os: [macos-latest, windows-2022]
     steps:
       - uses: actions/checkout@v2
       - uses: actions/setup-node@master


### PR DESCRIPTION
Error:

pre-release: .github#L1
windows-latest workflows now use windows-2022. For more details, see https://github.com/actions/virtual-environments/issues/4856