### PR TITLE
FIX - workflow error

### DIFF
--- a/apps/content-authoring/package.json
+++ b/apps/content-authoring/package.json
@@ -32,7 +32,8 @@
         {
           "name": "@electron-forge/maker-squirrel",
           "config": {
-            "name": "content_authoring"
+            "name": "content_authoring",
+            "description": "A tool to build accessible content for Learning Management Systems"
           }
         },
         {


### PR DESCRIPTION
Error: Failed with exit code: 1
Output:
Attempting to build package from 'content_authoring.nuspec'.
Description is required.